### PR TITLE
Load substitution files directly in 'st.cmd'

### DIFF
--- a/iocBoot/iocpie621/st.cmd
+++ b/iocBoot/iocpie621/st.cmd
@@ -23,7 +23,8 @@ drvAsynIPPortConfigure("P0", "xf09id1-tsrv6.nsls2.bnl.gov:4001")
 E816CreateController("$(PI_PORT)", "P0", 1, 50)
 
 ## Load record instances
-dbLoadRecords("$(TOP)/db/motors.db", "P=$(P),PORT=$(PI_PORT)")
+dbLoadTemplate("${TOP}/db/motors.substitutions", "PP=$(P),PI_PORT=$(PI_PORT)")
+# dbLoadRecords("$(TOP)/db/motors.db", "P=$(P),PORT=$(PI_PORT)")
 dbLoadRecords("$(TOP)/db/asynComm.db","P=$(IOC_PREFIX),PORT=$(PI_PORT),ADDR=0")
 
 ## autosave/restore machinery

--- a/iocBoot/iocpie621/st.cmd
+++ b/iocBoot/iocpie621/st.cmd
@@ -8,7 +8,6 @@ epicsEnvSet("IOCNAME",   "pi-vms")
 epicsEnvSet("PI_PORT",   "PI_VMS")
 epicsEnvSet("IOC_PREFIX", "$(P){IOC:$(IOCNAME)}")
 
-
 < envPaths
 < /epics/common/xf09id1-ioc1-netsetup.cmd
 
@@ -24,7 +23,6 @@ E816CreateController("$(PI_PORT)", "P0", 1, 50)
 
 ## Load record instances
 dbLoadTemplate("${TOP}/db/motors.substitutions", "PP=$(P),PI_PORT=$(PI_PORT)")
-# dbLoadRecords("$(TOP)/db/motors.db", "P=$(P),PORT=$(PI_PORT)")
 dbLoadRecords("$(TOP)/db/asynComm.db","P=$(IOC_PREFIX),PORT=$(PI_PORT),ADDR=0")
 
 ## autosave/restore machinery
@@ -45,7 +43,6 @@ set_pass1_restoreFile("info_settings.sav")
 dbLoadRecords("$(EPICS_BASE)/db/save_restoreStatus.db","P=$(IOC_PREFIX)")
 dbLoadRecords("$(EPICS_BASE)/db/iocAdminSoft.db","IOC=$(IOC_PREFIX)")
 save_restoreSet_status_prefix("$(IOC_PREFIX)")
-#asSetFilename("/cf-update/acf/default.acf")
 
 iocInit()
 
@@ -59,4 +56,3 @@ create_monitor_set("info_settings.req", 15 , "")
 
 cd ${TOP}
 dbl > ./records.dbl
-#system "cp ./records.dbl /cf-update/$HOSTNAME.$IOCNAME.dbl"

--- a/pie621App/Db/Makefile
+++ b/pie621App/Db/Makefile
@@ -10,8 +10,10 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------------------
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
-DB += motors.db
+#DB += motors.db
+DB += asyn_motor.db
 DB += asynComm.db
+DB += motors.substitutions
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/pie621App/Db/Makefile
+++ b/pie621App/Db/Makefile
@@ -10,7 +10,6 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------------------
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
-#DB += motors.db
 DB += asyn_motor.db
 DB += asynComm.db
 DB += motors.substitutions

--- a/pie621App/Db/asyn_motor.db
+++ b/pie621App/Db/asyn_motor.db
@@ -1,6 +1,5 @@
 record(motor,"$(P)Mtr")
 {
-    alias("$(ALIAS)")
     field(DESC,"$(DESC)")
     field(DTYP,"$(DTYP)")
     field(OUT,"@asyn($(PORT),$(ADDR))")

--- a/pie621App/Db/motors.substitutions
+++ b/pie621App/Db/motors.substitutions
@@ -1,6 +1,6 @@
 file "$(TOP)/db/asyn_motor.db"
 {
 pattern
-{                   P,       PORT, ADDR,        DTYP,   ALIAS,    DESC,  EGU, DIR, TWV,  VELO, VBAS, ACCL, BDST, BVEL, BACC,     MRES, PREC, DHLM, DLLM, INIT}
-{"$(PP){Mono:HDCM-Ax:FP}", "$(PI_PORT)",    0, "asynMotor", "vms_pf", "vms_pf", urad, Pos,   1,    5.,  2.0,  0.1,    0,    1,   .2, 0.000001,    3,    0,    0,   ""}
+{                   P,       PORT, ADDR,        DTYP,   DESC,  EGU, DIR, TWV,  VELO, VBAS, ACCL, BDST, BVEL, BACC,     MRES, PREC, DHLM, DLLM, INIT}
+{"$(PP){Mono:HDCM-Ax:FP}", "$(PI_PORT)",    0, "asynMotor", "vms_pf", urad, Pos,   1,    5.,  2.0,  0.1,    0,    1,   .2, 0.000001,    3,    0,    0,   ""}
 }

--- a/pie621App/Db/motors.substitutions
+++ b/pie621App/Db/motors.substitutions
@@ -1,6 +1,6 @@
-file "asyn_motor.db"
+file "$(TOP)/db/asyn_motor.db"
 {
 pattern
 {                   P,       PORT, ADDR,        DTYP,   ALIAS,    DESC,  EGU, DIR, TWV,  VELO, VBAS, ACCL, BDST, BVEL, BACC,     MRES, PREC, DHLM, DLLM, INIT}
-{"$\(P){Mono:HDCM-Ax:FP}", "$\(PORT)",    0, "asynMotor", "vms_pf", "vms_pf", urad, Pos,   1,    5.,  2.0,  0.1,    0,    1,   .2, 0.000001,    3,    0,    0,   ""}
+{"$(PP){Mono:HDCM-Ax:FP}", "$(PI_PORT)",    0, "asynMotor", "vms_pf", "vms_pf", urad, Pos,   1,    5.,  2.0,  0.1,    0,    1,   .2, 0.000001,    3,    0,    0,   ""}
 }


### PR DESCRIPTION
Refactor the code so that substitution file is directly loaded in st.cmd instead of being used to generate db file during build. This is more consistent to how substitution files are used in the deployed roles.